### PR TITLE
Support Grafana

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@ Allows Gotify to receive [Slack Incoming Webhooks](https://api.slack.com/messagi
 **Support**
 
 - Read-only blocks from [Slack Block Kit](https://api.slack.com/reference/block-kit/blocks)
+- Most properties from [Legacy Message Attachments](https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments/)
 - Buttons pointing to URLs
 - Handles any non-supported block by stripping it
 - Does **NOT** implement any Slack specific interaction blocks (these are stripped)
@@ -116,6 +117,7 @@ If you have ideas how to automate the process, I'd love to review your PR.
 
 - [Slack Incoming Webhook documentation](https://api.slack.com/messaging/webhooks)
 - [Slack BlockKit](https://api.slack.com/block-kit)
+- [Legacy Message Attachments](https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments/)
 - [Gotify Plugin - Getting started](https://gotify.net/docs/plugin)
 - [Gotify Plugin - Reference](https://gotify.net/docs/plugin-write)
 - [Gotify Plugin API](https://pkg.go.dev/github.com/gotify/plugin-api)

--- a/legacy/attachment.go
+++ b/legacy/attachment.go
@@ -1,6 +1,8 @@
 package legacy
 
 import (
+	"strings"
+
 	"github.com/lukasknuth/gotify-slack-webhook/gotify"
 	"github.com/tidwall/gjson"
 )
@@ -52,29 +54,33 @@ func (la *Attachment) Parse(json *gjson.Result) bool {
 func (la *Attachment) Render(out *gotify.MarkdownWriter) error {
 	var err error
 	if la.Pretext != "" {
-		err := out.WriteMarkdownF("%s\n\n", la.Pretext)
+		err := out.WriteMarkdownF("%s\n\n", stripNewline(la.Pretext))
 		if err != nil {
 			return err
 		}
 	}
 	if la.AuthorName != "" {
 		if la.AuthorLink != "" {
-			err = out.WriteMarkdownF("> [%s](%s)\n>\n", la.AuthorName, la.AuthorLink)
+			err = out.WriteMarkdownF("> [%s](%s)\n>\n", stripNewline(la.AuthorName), stripNewline(la.AuthorLink))
 		} else {
-			err = out.WriteMarkdownF("> %s\n>\n", la.AuthorName)
+			err = out.WriteMarkdownF("> %s\n>\n", stripNewline(la.AuthorName))
 		}
 		if err != nil {
 			return err
 		}
 	}
 	if la.Title != "" {
-		err = out.WriteMarkdownF("> ### %s\n>\n", la.Title)
+		err = out.WriteMarkdownF("> ### %s\n>\n", stripNewline(la.Title))
 		if err != nil {
 			return err
 		}
 	}
 	if la.Text != "" {
-		err = out.WriteMarkdownF("> %s\n>\n", la.Text)
+		err = wrapInBlockquote(out, la.Text)
+		if err != nil {
+			return err
+		}
+		err = out.WriteMarkdown(">\n")
 		if err != nil {
 			return err
 		}
@@ -90,14 +96,25 @@ func (la *Attachment) Render(out *gotify.MarkdownWriter) error {
 				return err
 			}
 		}
+		err = out.WriteMarkdown(">\n")
+		if err != nil {
+			return err
+		}
 	}
-	// NOTE: The main attachment above does not render an empty line inside the quote.
-	// This is so that we don't generate a trailing empty-line in the quote.
-	// Now, we ensure that we add an empty-line **outside** the quote to finish off.
 	if la.Footer != "" {
-		err = out.WriteMarkdownF("\n> %s\n\n", la.Footer)
+		err = out.WriteMarkdownF("> %s\n\n", stripNewline(la.Footer))
 	} else if la.hasContent() {
 		err = out.NewLine()
 	}
 	return err
+}
+
+func stripNewline(text string) string {
+	return strings.TrimSpace(strings.ReplaceAll(text, "\n", " "))
+}
+
+func wrapInBlockquote(out *gotify.MarkdownWriter, text string) error {
+	text = strings.TrimSpace(text)
+	text = strings.ReplaceAll(text, "\n", "\n> ")
+	return out.WriteMarkdownF("> %s\n", text)
 }

--- a/legacy/attachment.go
+++ b/legacy/attachment.go
@@ -1,0 +1,112 @@
+package legacy
+
+import (
+	"github.com/lukasknuth/gotify-slack-webhook/gotify"
+	"github.com/tidwall/gjson"
+)
+
+type Attachment struct {
+	Pretext    string
+	AuthorName string
+	AuthorLink string
+	Title      string
+	Text       string
+	Fallback   string
+	Footer     string
+	Fields     []*AttachmentField
+}
+
+func (la *Attachment) hasContent() bool {
+	return la.Fallback != "" || la.Text != "" || len(la.Fields) > 0
+}
+
+func (la *Attachment) Parse(json *gjson.Result) bool {
+	if pretext := json.Get("pretext"); pretext.Exists() {
+		la.Pretext = pretext.String()
+	}
+	if author_name := json.Get("author_name"); author_name.Exists() {
+		la.AuthorName = author_name.String()
+	}
+	if author_link := json.Get("author_link"); author_link.Exists() {
+		la.AuthorLink = author_link.String()
+	}
+	if title := json.Get("title"); title.Exists() {
+		la.Title = title.String()
+	}
+	if text := json.Get("text"); text.Exists() {
+		la.Text = text.String()
+	}
+	if fallback := json.Get("fallback"); fallback.Exists() {
+		la.Fallback = fallback.String()
+	}
+	if footer := json.Get("footer"); footer.Exists() {
+		la.Footer = footer.String()
+	}
+	json.Get("fields").ForEach(func(_, value gjson.Result) bool {
+		field := &AttachmentField{}
+		skip := field.Parse(&value)
+		if !skip {
+			la.Fields = append(la.Fields, field)
+		}
+		return true
+	})
+	return !la.hasContent()
+}
+
+func (la *Attachment) Render(out *gotify.MarkdownWriter) error {
+	var err error
+	if la.Pretext != "" {
+		err := out.WriteMarkdownF("%s\n\n", la.Pretext)
+		if err != nil {
+			return err
+		}
+	}
+	if la.AuthorName != "" {
+		if la.AuthorLink != "" {
+			err = out.WriteMarkdownF("> [%s](%s)\n>\n", la.AuthorName, la.AuthorLink)
+		} else {
+			err = out.WriteMarkdownF("> %s\n>\n", la.AuthorName)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	if la.Title != "" {
+		err = out.WriteMarkdownF("> ### %s\n>\n", la.Title)
+		if err != nil {
+			return err
+		}
+	}
+	if la.Text != "" {
+		err = out.WriteMarkdownF("> %s\n>\n", la.Text)
+		if err != nil {
+			return err
+		}
+	}
+	if len(la.Fields) > 0 {
+		for _, field := range la.Fields {
+			err = out.WriteMarkdownF("> ")
+			if err != nil {
+				return err
+			}
+			err = field.Render(out)
+			if err != nil {
+				return err
+			}
+		}
+	} else if la.Fallback != "" {
+		err = out.WriteMarkdownF("> %s\n", la.Fallback)
+		if err != nil {
+			return err
+		}
+	}
+	// NOTE: The main attachment above does not render an empty line inside the quote.
+	// This is so that we don't generate a trailing empty-line in the quote.
+	// Now, we ensure that we add an empty-line **outside** the quote to finish off.
+	if la.Footer != "" {
+		err = out.WriteMarkdownF("\n> %s\n\n", la.Footer)
+	} else if la.hasContent() {
+		err = out.NewLine()
+	}
+	return err
+}

--- a/legacy/attachment.go
+++ b/legacy/attachment.go
@@ -11,13 +11,12 @@ type Attachment struct {
 	AuthorLink string
 	Title      string
 	Text       string
-	Fallback   string
 	Footer     string
 	Fields     []*AttachmentField
 }
 
 func (la *Attachment) hasContent() bool {
-	return la.Fallback != "" || la.Text != "" || len(la.Fields) > 0
+	return la.Text != "" || len(la.Fields) > 0
 }
 
 func (la *Attachment) Parse(json *gjson.Result) bool {
@@ -35,9 +34,6 @@ func (la *Attachment) Parse(json *gjson.Result) bool {
 	}
 	if text := json.Get("text"); text.Exists() {
 		la.Text = text.String()
-	}
-	if fallback := json.Get("fallback"); fallback.Exists() {
-		la.Fallback = fallback.String()
 	}
 	if footer := json.Get("footer"); footer.Exists() {
 		la.Footer = footer.String()
@@ -93,11 +89,6 @@ func (la *Attachment) Render(out *gotify.MarkdownWriter) error {
 			if err != nil {
 				return err
 			}
-		}
-	} else if la.Fallback != "" {
-		err = out.WriteMarkdownF("> %s\n", la.Fallback)
-		if err != nil {
-			return err
 		}
 	}
 	// NOTE: The main attachment above does not render an empty line inside the quote.

--- a/legacy/attachment_test.go
+++ b/legacy/attachment_test.go
@@ -1,0 +1,90 @@
+package legacy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lukasknuth/gotify-slack-webhook/gotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestAttachmentParse(t *testing.T) {
+	t.Run("skips for empty input", func(t *testing.T) {
+		attachment := &Attachment{}
+		json := gjson.Parse("")
+		skip := attachment.Parse(&json)
+		assert.True(t, skip)
+	})
+
+	t.Run("skips if no content", func(t *testing.T) {
+		attachment := &Attachment{}
+		json := gjson.Parse(`{"author_name":"Tester","title":"Test"}`)
+		skip := attachment.Parse(&json)
+		assert.True(t, skip)
+	})
+
+	t.Run("parses valid input", func(t *testing.T) {
+		attachment := &Attachment{}
+		json := gjson.Parse(`{
+			"pretext":"Pretext",
+			"author_name":"Author",
+			"author_link":"http://test",
+			"title":"Title",
+			"text":"Text here",
+			"fallback":"Fallback text",
+			"footer":"My foot",
+			"fields":[{"title":"f_title","value":"f_val","short":true}]
+		}`)
+		skip := attachment.Parse(&json)
+		assert.False(t, skip)
+		assert.Equal(t, "Pretext", attachment.Pretext)
+		assert.Equal(t, "Author", attachment.AuthorName)
+		assert.Equal(t, "http://test", attachment.AuthorLink)
+		assert.Equal(t, "Title", attachment.Title)
+		assert.Equal(t, "Text here", attachment.Text)
+		assert.Equal(t, "Fallback text", attachment.Fallback)
+		assert.Equal(t, "My foot", attachment.Footer)
+		assert.Equal(t, "f_title", attachment.Fields[0].Title)
+		assert.Equal(t, "f_val", attachment.Fields[0].Value)
+	})
+}
+
+func TestAttachmentRender(t *testing.T) {
+	t.Run("renders nothing for empty struct", func(t *testing.T) {
+		attachment := &Attachment{}
+		buffer := new(bytes.Buffer)
+		err := attachment.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Empty(t, buffer.Bytes())
+	})
+
+	t.Run("renders full output", func(t *testing.T) {
+		attachment := &Attachment{
+			Pretext:    "Pretext",
+			AuthorName: "Lukas",
+			AuthorLink: "http://test",
+			Title:      "Testing",
+			Text:       "Text here",
+			Fallback:   "Should not see this",
+			Footer:     "Bottom",
+			Fields: []*AttachmentField{
+				{Title: "Title", Value: "Value"},
+			},
+		}
+		buffer := new(bytes.Buffer)
+		err := attachment.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Equal(t, "Pretext\n\n> [Lukas](http://test)\n>\n> ### Testing\n>\n> Text here\n>\n> - **Title**: Value\n\n> Bottom\n\n", buffer.String())
+	})
+
+	t.Run("renders minimal fallback", func(t *testing.T) {
+		attachment := &Attachment{
+			Fallback: "This is all I have",
+		}
+		buffer := new(bytes.Buffer)
+		err := attachment.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Equal(t, "> This is all I have\n\n", buffer.String())
+	})
+}

--- a/legacy/attachment_test.go
+++ b/legacy/attachment_test.go
@@ -57,6 +57,28 @@ func TestAttachmentRender(t *testing.T) {
 		assert.Empty(t, buffer.Bytes())
 	})
 
+	t.Run("wraps multiline text in blockquote", func(t *testing.T) {
+		attachment := &Attachment{Text: "This\nis\na\ntest!"}
+		buffer := new(bytes.Buffer)
+		err := attachment.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Equal(t, "> This\n> is\n> a\n> test!\n>\n\n", buffer.String())
+	})
+
+	t.Run("strips newlines from most data", func(t *testing.T) {
+		attachment := &Attachment{
+			Pretext:    "Pre\ntext",
+			AuthorName: "Lukas\n",
+			Title:      "\nTest\ning",
+			Text:       "Text\nhere",
+			Footer:     "\nBottom\n\n",
+		}
+		buffer := new(bytes.Buffer)
+		err := attachment.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Equal(t, "Pre text\n\n> Lukas\n>\n> ### Test ing\n>\n> Text\n> here\n>\n> Bottom\n\n", buffer.String())
+	})
+
 	t.Run("renders full output", func(t *testing.T) {
 		attachment := &Attachment{
 			Pretext:    "Pretext",
@@ -72,6 +94,6 @@ func TestAttachmentRender(t *testing.T) {
 		buffer := new(bytes.Buffer)
 		err := attachment.Render(gotify.Wrap(buffer))
 		assert.Nil(t, err)
-		assert.Equal(t, "Pretext\n\n> [Lukas](http://test)\n>\n> ### Testing\n>\n> Text here\n>\n> - **Title**: Value\n\n> Bottom\n\n", buffer.String())
+		assert.Equal(t, "Pretext\n\n> [Lukas](http://test)\n>\n> ### Testing\n>\n> Text here\n>\n> - **Title**: Value\n>\n> Bottom\n\n", buffer.String())
 	})
 }

--- a/legacy/attachment_test.go
+++ b/legacy/attachment_test.go
@@ -32,7 +32,6 @@ func TestAttachmentParse(t *testing.T) {
 			"author_link":"http://test",
 			"title":"Title",
 			"text":"Text here",
-			"fallback":"Fallback text",
 			"footer":"My foot",
 			"fields":[{"title":"f_title","value":"f_val","short":true}]
 		}`)
@@ -43,7 +42,6 @@ func TestAttachmentParse(t *testing.T) {
 		assert.Equal(t, "http://test", attachment.AuthorLink)
 		assert.Equal(t, "Title", attachment.Title)
 		assert.Equal(t, "Text here", attachment.Text)
-		assert.Equal(t, "Fallback text", attachment.Fallback)
 		assert.Equal(t, "My foot", attachment.Footer)
 		assert.Equal(t, "f_title", attachment.Fields[0].Title)
 		assert.Equal(t, "f_val", attachment.Fields[0].Value)
@@ -66,7 +64,6 @@ func TestAttachmentRender(t *testing.T) {
 			AuthorLink: "http://test",
 			Title:      "Testing",
 			Text:       "Text here",
-			Fallback:   "Should not see this",
 			Footer:     "Bottom",
 			Fields: []*AttachmentField{
 				{Title: "Title", Value: "Value"},
@@ -76,15 +73,5 @@ func TestAttachmentRender(t *testing.T) {
 		err := attachment.Render(gotify.Wrap(buffer))
 		assert.Nil(t, err)
 		assert.Equal(t, "Pretext\n\n> [Lukas](http://test)\n>\n> ### Testing\n>\n> Text here\n>\n> - **Title**: Value\n\n> Bottom\n\n", buffer.String())
-	})
-
-	t.Run("renders minimal fallback", func(t *testing.T) {
-		attachment := &Attachment{
-			Fallback: "This is all I have",
-		}
-		buffer := new(bytes.Buffer)
-		err := attachment.Render(gotify.Wrap(buffer))
-		assert.Nil(t, err)
-		assert.Equal(t, "> This is all I have\n\n", buffer.String())
 	})
 }

--- a/legacy/field.go
+++ b/legacy/field.go
@@ -1,0 +1,33 @@
+package legacy
+
+import (
+	"github.com/lukasknuth/gotify-slack-webhook/gotify"
+	"github.com/tidwall/gjson"
+)
+
+type AttachmentField struct {
+	Title string
+	Value string
+}
+
+func (af *AttachmentField) Parse(json *gjson.Result) bool {
+	if title := json.Get("title"); title.Exists() {
+		af.Title = title.String()
+	}
+	if value := json.Get("value"); value.Exists() {
+		af.Value = value.String()
+	}
+	return af.Value == ""
+}
+
+func (af *AttachmentField) Render(out *gotify.MarkdownWriter) error {
+	if af.Value != "" {
+		if af.Title != "" {
+			return out.WriteMarkdownF("- **%s**: %s\n", af.Title, af.Value)
+		} else {
+			return out.WriteMarkdownF("- %s\n", af.Value)
+		}
+	} else {
+		return nil
+	}
+}

--- a/legacy/field_test.go
+++ b/legacy/field_test.go
@@ -1,0 +1,66 @@
+package legacy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lukasknuth/gotify-slack-webhook/gotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestAttachmentFieldParse(t *testing.T) {
+	t.Run("skips entry if input empty", func(t *testing.T) {
+		field := &AttachmentField{}
+		json := gjson.Parse("")
+		skip := field.Parse(&json)
+		assert.True(t, skip)
+	})
+
+	t.Run("skips entry if no content", func(t *testing.T) {
+		field := &AttachmentField{}
+		json := gjson.Parse(`{"title":"my title"}`)
+		skip := field.Parse(&json)
+		assert.True(t, skip)
+	})
+
+	t.Run("parses valid input", func(t *testing.T) {
+		field := &AttachmentField{}
+		json := gjson.Parse(`{"title":"hello","value":"world"}`)
+		skip := field.Parse(&json)
+		assert.False(t, skip)
+		assert.Equal(t, "hello", field.Title)
+		assert.Equal(t, "world", field.Value)
+	})
+}
+
+func TestAttachmentFieldRender(t *testing.T) {
+	t.Run("renders nothing for empty struct", func(t *testing.T) {
+		field := &AttachmentField{}
+		buffer := new(bytes.Buffer)
+		err := field.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Empty(t, buffer.Bytes())
+	})
+
+	t.Run("renders title if present", func(t *testing.T) {
+		field := &AttachmentField{
+			Title: "Hello",
+			Value: "World",
+		}
+		buffer := new(bytes.Buffer)
+		err := field.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Equal(t, "- **Hello**: World\n", buffer.String())
+	})
+
+	t.Run("renders value only if no title", func(t *testing.T) {
+		field := &AttachmentField{
+			Value: "World",
+		}
+		buffer := new(bytes.Buffer)
+		err := field.Render(gotify.Wrap(buffer))
+		assert.Nil(t, err)
+		assert.Equal(t, "- World\n", buffer.String())
+	})
+}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func (c *Plugin) RegisterWebhook(basePath string, mux *gin.RouterGroup) {
 				Message: err.Error(),
 			})
 		}
-		endpoint.String(http.StatusOK, "OK")
+		endpoint.String(http.StatusOK, "ok")
 	})
 }
 

--- a/webhook/body.go
+++ b/webhook/body.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/lukasknuth/gotify-slack-webhook/blockkit"
 	"github.com/lukasknuth/gotify-slack-webhook/gotify"
+	"github.com/lukasknuth/gotify-slack-webhook/legacy"
 	"github.com/tidwall/gjson"
 )
 
 type WebhookBody struct {
-	Text   string
-	Blocks []blockkit.Block
+	Text        string
+	Blocks      []blockkit.Block
+	Attachments []legacy.Attachment
 }
 
 func (wb *WebhookBody) Parse(requestBody []byte) error {
@@ -28,6 +30,14 @@ func (wb *WebhookBody) Parse(requestBody []byte) error {
 			continue
 		} else {
 			wb.Blocks = append(wb.Blocks, parsed)
+		}
+	}
+	attachments := json.Get("attachments")
+	for _, block := range attachments.Array() {
+		attachment := legacy.Attachment{}
+		skip := attachment.Parse(&block)
+		if !skip {
+			wb.Attachments = append(wb.Attachments, attachment)
 		}
 	}
 	return nil
@@ -76,6 +86,12 @@ func (wb *WebhookBody) Render() (string, error) {
 	}
 	for _, block := range wb.Blocks {
 		err := block.Render(out)
+		if err != nil {
+			return "", err
+		}
+	}
+	for _, attachment := range wb.Attachments {
+		err := attachment.Render(out)
 		if err != nil {
 			return "", err
 		}

--- a/webhook/body_test.go
+++ b/webhook/body_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lukasknuth/gotify-slack-webhook/blockkit"
+	"github.com/lukasknuth/gotify-slack-webhook/legacy"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,6 +142,21 @@ const webhookBodyValid = `{
 		}
 	]
 }`
+const webhookBodyGrafana = `{
+   "attachments": [
+      {
+         "color": "#D63232",
+         "fallback": "[FIRING:1] TestAlert Test Folder Grafana ",
+         "footer": "Grafana v12.2.1",
+         "footer_icon": "https://grafana.com/static/assets/img/fav32.png",
+         "text": "**Firing**\n\nValue: B=22, C=1\nLabels:\n - alertname = TestAlert\n - grafana_folder = Test Folder\n - instance = Grafana\nAnnotations:\n - description = aaaa\n - summary = aaaa\nSource: ?orgId=1\nSilence: https://mon.local/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTestAlert&matcher=grafana_folder%3DTest+Folder&matcher=instance%3DGrafana&orgId=1\nDashboard: https://mon.local/d/dashboard_uid?from=1776157732785&orgId=1&to=1776161332796\nPanel: https://mon.local/d/dashboard_uid?from=1776157732785&orgId=1&to=1776161332796&viewPanel=1\n",
+         "title": "[FIRING:1] TestAlert Test Folder Grafana ",
+         "title_link": "?orgId=1",
+         "ts": 1776161332
+      }
+   ],
+   "username": "Grafana"
+}`
 
 func TestWebhookBodyParse(t *testing.T) {
 	t.Run("does not fail for empty input", func(t *testing.T) {
@@ -174,6 +190,16 @@ func TestWebhookBodyParse(t *testing.T) {
 		assert.IsType(t, &blockkit.VideoBlock{}, payload.Blocks[5])
 		assert.Len(t, payload.Blocks, 6)
 	})
+
+	t.Run("parses legacy attachments", func(t *testing.T) {
+		payload := &WebhookBody{}
+		err := payload.Parse([]byte(webhookBodyGrafana))
+		assert.Nil(t, err)
+		assert.Empty(t, payload.Text)
+		assert.Empty(t, payload.Blocks)
+		assert.IsType(t, legacy.Attachment{}, payload.Attachments[0])
+		assert.Len(t, payload.Attachments, 1)
+	})
 }
 
 func TestWebhookBodyRender(t *testing.T) {
@@ -195,5 +221,22 @@ func TestWebhookBodyRender(t *testing.T) {
 		out, err := payload.Render()
 		assert.Nil(t, err)
 		assert.Equal(t, "The simple text here\n## Headline\n\n\n\n---\n\n", out)
+	})
+
+	t.Run("renders legacy attachment", func(t *testing.T) {
+		payload := &WebhookBody{
+			Text: "Normal Text",
+			Blocks: []blockkit.Block{
+				&blockkit.HeaderBlock{PlainText: "A block!"},
+			},
+			Attachments: []legacy.Attachment{{
+				Footer: "Grafana v12",
+				Text:   "**Firing**\n\nsomething is broken",
+				Title:  "[FIRING:1] TestAlert",
+			}},
+		}
+		out, err := payload.Render()
+		assert.Nil(t, err)
+		assert.Equal(t, "Normal Text\n## A block!\n\n> ### [FIRING:1] TestAlert\n>\n> **Firing**\n> \n> something is broken\n>\n> Grafana v12\n\n", out)
 	})
 }


### PR DESCRIPTION
This resolves #6 by adding support for the [Legacy Message Attachments](https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments/).